### PR TITLE
fix class argument when calling super class

### DIFF
--- a/pcer/code_viewer.py
+++ b/pcer/code_viewer.py
@@ -10,10 +10,10 @@ class MyQTextEdit(QTextEdit):
     scrollbar_displacement = 0
 
     def __init__(self, parent=None):
-        super(QTextEdit, self).__init__(parent)
+        super(MyQTextEdit, self).__init__(parent)
 
     def scrollContentsBy(self, dx, dy):
-        super(QTextEdit, self).scrollContentsBy(dx, dy)
+        super(MyQTextEdit, self).scrollContentsBy(dx, dy)
         self.scrollbar_displacement+=dy
         print(self.scrollbar_displacement)
 
@@ -21,8 +21,8 @@ class CodeViewer(PcerWindow):
 
     back = QtCore.pyqtSignal()
 
-    def __init__(self, parent=None):
-        super(QWidget, self).__init__(parent)
+    def __init__(self):
+        super(CodeViewer, self).__init__()
         self.initBaseUI()
         self.listWidth = self.width/4
         self.backButtonWidth = self.listWidth/2

--- a/pcer/participant_form.py
+++ b/pcer/participant_form.py
@@ -9,7 +9,7 @@ class ParticipantForm(PcerWindow):
     continue_with_the_experiment = QtCore.pyqtSignal()
 
     def __init__(self):
-        super(QWidget, self).__init__()
+        super(ParticipantForm, self).__init__()
         self.initBaseUI()
         self.initUI()
 

--- a/pcer/pcer_window.py
+++ b/pcer/pcer_window.py
@@ -4,8 +4,8 @@ from PyQt5 import QtCore
 
 class PcerWindow(QWidget):
 
-    def __init__(self, parent=None):
-        super(QWidget, self).__init__(parent)
+    def __init__(self):
+        super(PcerWindow, self).__init__()
 
     def initBaseUI(self):
     	self.setWindowFlags(QtCore.Qt.CustomizeWindowHint)

--- a/pcer/system_form.py
+++ b/pcer/system_form.py
@@ -10,7 +10,7 @@ class SystemForm(PcerWindow):
     show_task = QtCore.pyqtSignal()
 
     def __init__(self):
-        super(QWidget, self).__init__()
+        super(SystemForm, self).__init__()
         self.initBaseUI()
         self.initUI()
 

--- a/pcer/task_form.py
+++ b/pcer/task_form.py
@@ -10,7 +10,7 @@ class TaskForm(PcerWindow):
     read_code = QtCore.pyqtSignal()
 
     def __init__(self):
-        super(QWidget, self).__init__()
+        super(TaskForm, self).__init__()
         self.initBaseUI()
         self.initUI()
 


### PR DESCRIPTION
In a 'super' call, the first parameter now refers to the subclass. This causes super() to start searching for a matching method at one level above in the hierarchy, i.e. the super class.